### PR TITLE
Jumped up on IRI 1.3.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM maven:3.5-jdk-8
 
 WORKDIR /iri
 
-RUN git clone -b v1.3.2 https://github.com/iotaledger/iri.git /iri/
+RUN git clone -b v1.3.2.1 https://github.com/iotaledger/iri.git /iri/
 RUN mvn clean package
 
 COPY conf /iri/conf

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,4 +6,4 @@ for buddy in $(cat /iri/conf/neighbors); do
 done
 neighbors=${neighbors::-1}
 
-exec java -XX:+DisableAttachMechanism -Xmx4g -Xms4g -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri-1.3.2.jar -p 14265 -u 14777 -t 15777 -n "$neighbors" --remote --remote-limit-api "attachToTangle, addNeighbors, removeNeighbors" --send-limit 100.0 "$@"
+exec java -XX:+DisableAttachMechanism -Xmx4g -Xms4g -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri-1.3.2.1.jar -p 14265 -u 14777 -t 15777 -n "$neighbors" --remote --remote-limit-api "attachToTangle, addNeighbors, removeNeighbors" --send-limit 100.0 "$@"


### PR DESCRIPTION
I did not add `--revalidate` into the entrypoint script but I think there should be a way to set that flag when starting docker. Your thoughts?