### PR TITLE
Make iri ports and remote-api-limit configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5-jdk-9-slim as build
 
-# procps is very common in build systems, and is a reasonably small package
+# install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		git \
 	&& rm -rf /var/lib/apt/lists/*
@@ -15,10 +15,14 @@ FROM openjdk:9-jre-slim
 
 COPY --from=build /iri/target/iri*.jar /iri/target/
 COPY conf/* /iri/conf/
-COPY /docker-entrypoint.sh /
+COPY docker-entrypoint.sh /
 
 ENV MIN_MEMORY 2G
 ENV MAX_MEMORY 4G
+
+ENV API_PORT 14265
+ENV UDP_PORT 14600
+ENV TCP_PORT 15600
 
 VOLUME /iri/data
 VOLUME /iri/conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ ENV API_PORT 14265
 ENV UDP_PORT 14600
 ENV TCP_PORT 15600
 
+# mark ports for expose
+EXPOSE $API_PORT
+EXPOSE $UDP_PORT/UDP
+EXPOSE $TCP_PORT
+
 # default remote api limitations
 ENV REMOTE_API_LIMIT "attachToTangle, addNeighbors, removeNeighbors"	 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ ENV API_PORT 14265
 ENV UDP_PORT 14600
 ENV TCP_PORT 15600
 
+# default remote api limitations
+ENV REMOTE_API_LIMIT "attachToTangle, addNeighbors, removeNeighbors"	 
+
 VOLUME /iri/data
 VOLUME /iri/conf
 

--- a/conf/iri.ini
+++ b/conf/iri.ini
@@ -1,0 +1,4 @@
+[IRI]
+HEADLESS = true
+DEBUG = true
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,4 +10,4 @@ p="${API_PORT:-14265}"
 u="${UDP_PORT:-14600}"
 t="${TCP_PORT:-15600}"
 
-exec java --add-modules java.xml.bind -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar -p $p -u $u -t $t -n "$neighbors" --remote --remote-limit-api "attachToTangle, addNeighbors, removeNeighbors" "$@"
+exec java --add-modules java.xml.bind -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar -p $p -u $u -t $t -n "$neighbors" --remote --remote-limit-api "$REMOTE_API_LIMIT" "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,4 +10,4 @@ p="${API_PORT:-14265}"
 u="${UDP_PORT:-14600}"
 t="${TCP_PORT:-15600}"
 
-exec java --add-modules java.xml.bind -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar -p $p -u $u -t $t -n "$neighbors" --remote --remote-limit-api "$REMOTE_API_LIMIT" "$@"
+exec java --add-modules java.xml.bind -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar --config /iri/conf/iri.ini --port $p --udp-receiver-port $u --tcp-receiver-port $t --neighbors "$neighbors" --remote --remote-limit-api "$REMOTE_API_LIMIT" "$@"

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-docker run -d --name iota-node -p 14265:14265 -p 14777:14777/udp -p 15777:15777 -v $data_volume:/iri/data -v $conf_volume:/iri/conf --env MIN_MEMORY=2g --env MAX_MEMORY=4g --restart=always iota-node:latest "$@"
+docker run -d --name iota-node -p 14265:14265 -p 14777:14777/udp -p 15777:15777 -v $data_volume:/iri/data -v $conf_volume:/iri/conf --env MIN_MEMORY=2g --env MAX_MEMORY=4g --env API_PORT=14265 --env UDP_PORT=14777 --env TCP_PORT=15777 --restart=always iota-node:latest "$@"


### PR DESCRIPTION
Added environment variables for ports and remote-api-limit parameter.
Fixed issue #9 