### PR TITLE
Jre8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone -b master https://github.com/iotaledger/iri.git /iri/
 RUN mvn clean package
 
 # execution image
-FROM openjdk:9-jre-slim
+FROM openjdk:8-jre-slim
 
 COPY --from=build /iri/target/iri*.jar /iri/target/
 COPY conf/* /iri/conf/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,4 +10,4 @@ p="${API_PORT:-14265}"
 u="${UDP_PORT:-14600}"
 t="${TCP_PORT:-15600}"
 
-exec java --add-modules java.xml.bind -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar --config /iri/conf/iri.ini --port $p --udp-receiver-port $u --tcp-receiver-port $t --neighbors "$neighbors" --remote --remote-limit-api "$REMOTE_API_LIMIT" "$@"
+exec java -XX:+DisableAttachMechanism -Xms$MIN_MEMORY -Xmx$MAX_MEMORY -Dlogback.configurationFile=/iri/conf/logback.xml -Djava.net.preferIPv4Stack=true -jar /iri/target/iri*.jar --config /iri/conf/iri.ini --port $p --udp-receiver-port $u --tcp-receiver-port $t --neighbors "$neighbors" --remote --remote-limit-api "$REMOTE_API_LIMIT" "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,7 +10,6 @@ exec java \
   $JAVA_OPTIONS \
   -Djava.net.preferIPv4Stack=true \
   -Dlogback.configurationFile=/iri/conf/logback.xml \
-  --add-modules java.xml.bind \
   -jar /iri/target/iri*.jar \
   --config /iri/conf/iri.ini \
   --port $API_PORT \


### PR DESCRIPTION
Should fix #18 

- Removed --add-modules parameter.

We can go back to JRE 9 as soon as all dependencies support the new Java version.

Can you please review the PR?

Thanks,
Merlin