### PR TITLE
https://github.com/iotaledger/iri/pull/1295 - Setting --remote to 'true'

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@ exec java \
   --port $API_PORT \
   --udp-receiver-port $UDP_PORT \
   --tcp-receiver-port $TCP_PORT \
-  --remote --remote-limit-api "$REMOTE_API_LIMIT" \
+  --remote=true --remote-limit-api "$REMOTE_API_LIMIT" \
   --neighbors "$neighbors" \
   "$@"
   


### PR DESCRIPTION
IRI 1.7.1 won't start correctly if --remote is not defined as a true boolean value.