### PR TITLE
IRI 1.8.0 clean-up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,12 @@ COPY --from=build /iri/target/iri*.jar /iri/target/
 COPY conf/* /iri/conf/
 COPY docker-entrypoint.sh /
 
-# Allow change of ports in the container.
-# See Issue #2 for description why this is needed (https://github.com/bluedigits/iota-node/issues/2)
+# Allow change of ports in the container. 
 ENV API_PORT 14265
-ENV UDP_PORT 14600
-ENV TCP_PORT 15600
+ENV TCP_PORT 15600 
+
+# Allow change of bind address
+ENV TCP_SOCKET_ADDRESS "0.0.0.0"
 
 # Default jvm arguments
 ENV JAVA_OPTIONS "-XX:+DisableAttachMechanism -XX:+HeapDumpOnOutOfMemoryError"
@@ -45,7 +46,6 @@ ENV REMOTE_API_LIMIT "attachToTangle, addNeighbors, removeNeighbors"
 
 # Mark ports for expose
 EXPOSE $API_PORT
-EXPOSE $UDP_PORT/UDP
 EXPOSE $TCP_PORT
 
 WORKDIR /iri/data

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ We assume that you want to run IRI with Nelson managing your neighbours, as this
 
 #### Option 1: Run IRI with Nelson
 1. Invoke _docker run_ as follows:
-`docker run -d --net=host --name iota-node -e API_PORT=14265 -e UDP_PORT=14600 -e TCP_PORT=15600 -v /iri/data:/iri/data bluedigits/iota-node:latest`
+`docker run -d --net=host --name iota-node -e API_PORT=14265 -e TCP_PORT=15600 -v /iri/data:/iri/data bluedigits/iota-node:latest`
 2. Invoke _docker run_ again to spin up a Nelson instance (can be skipped if you want to specify your neighbors manually):
-`docker run -d --net=host -p 18600:18600 --name nelson romansemko/nelson.cli -r localhost -i 14265 -u 14600 -t 15600 --getNeighbors`
+`docker run -d --net=host -p 18600:18600 --name nelson romansemko/nelson.cli -r localhost -i 14265 -t 15600 --getNeighbors`
 
 #### Option 2: Run IRI with static neighbors
 If you decide to manually manage your peers without Nelson, please do the following.
 1. Create a text file `/iri/conf/neighbors` and specify your neighbors IPs, one neighbor per line.
 2. Call the _docker run_ command as follows:
-`docker run -d --net=host --name iota-node -e API_PORT=14265 -e UDP_PORT=14600 -e TCP_PORT=15600 -v /iri/data:/iri/data -v /iri/conf/neighbors:/iri/conf/neighbors bluedigits/iota-node:latest`
+`docker run -d --net=host --name iota-node -e API_PORT=14265 -e TCP_PORT=15600 -v /iri/data:/iri/data -v /iri/conf/neighbors:/iri/conf/neighbors bluedigits/iota-node:latest`
 
 ## Additional Parameters
 You can specifiy IRI parameters to the end of your `docker run` command chain, e.g. you want IRI to revalidate it's database, just add `--revalidate`.
 
-Full command would be then: `docker run -d --net=host --name iota-node -e API_PORT=14265 -e UDP_PORT=14600 -e TCP_PORT=15600 -v /iri/data:/iri/data -v /iri/conf/neighbors:/iri/conf/neighbors bluedigits/iota-node:latest --revalidate`
+Full command would be then: `docker run -d --net=host --name iota-node -e API_PORT=14265 -e TCP_PORT=15600 -v /iri/data:/iri/data -v /iri/conf/neighbors:/iri/conf/neighbors bluedigits/iota-node:latest --revalidate`
 
 ## API Limits
 You can forbid API commands you don't want IRI to interpret by specifying another ENV variable named `REMOTE_API_LIMIT`. This is by default set to `"attachToTangle, addNeighbors, removeNeighbors"`.
@@ -35,10 +35,13 @@ You can forbid API commands you don't want IRI to interpret by specifying anothe
 **Example:** You want IRI to forbid the `getNeighbors` command but to allow anything else, just specify `-e REMOTE_API_LIMIT "getNeighbors"`. Multiple limits have to be comma-separated.
 
 ## Ports
-You can specify a different API port and different UDP/TCP receiver ports by changing the values behind the -e flags when invoking _docker run_.
+You can specify a different API port and different TCP receiver ports by changing the values behind the -e flags when invoking _docker run_.
 * API_PORT: The port IRI listens on for receiving API commands, i.e. `getNeighbors`, `attachToTangle`, etc.
-* UDP_PORT: The UDP port IRI listens on for mutually exchanging transactions.
-* TCP_PORT: The TPC port IRI listens on for mutually exchanging transactions.
+* TCP_PORT: The TCP port IRI listens on for mutually exchanging transactions. (NEIGHBORING_SOCKET_PORT)
+
+## TCP listen address
+You can specify an alternate TCP socket address. (Default: 0.0.0.0)
+* TCP_SOCKET_ADDRESS: The TCP socket address used by IRI. (NEIGHBORING_SOCKET_ADDRESS)
 
 ## Java Options
 You can specify a custom set of Java JVM arguments by adding the environment variable JAVA_OPTIONS when invoking _docker run_. Please note that you have to include the defaults for JAVA_OPTIONS if you don't want to remove them!

--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Example:
 The syncing process takes a while so be patient. You can watch the logging with: `docker logs iota-node -f`.
 
 ## Neighbors
-If you're using Nelson you don't have manage your neighbors. However, if you want to specify your own neighbors add them to your `neighbors` file by adding the UDP or TCP IPs and the corresponding ports, one per line.
+If you're using Nelson you don't have manage your neighbors. However, if you want to specify your own neighbors add them to your `neighbors` file by adding the TCP IPs and the corresponding ports, one per line.
 
 Example:
 ```
-udp://neighbor1:14600
-udp://neighbor2:14600
+tcp://neighbor1:14600
+tcp://neighbor2:14600
 ```
 ## Memory Options
 Memory options are currently not used in the image because we suggest to run without explicit memory options for java heap. Majority of memory is consumed by RocksDB and this is native memory and not limited by the -Xmx and -Xms options. So we don't want to bind physical memory to java heap which is most of the time not required by iri. The idea is to leave as much memory as possible unbound and available for RocksDB.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -13,10 +13,10 @@ exec java \
   -Dlogback.configurationFile=/iri/conf/logback.xml \
   -jar /iri/target/iri*.jar \
   --config /iri/conf/iri.ini \
+  --neighboring-socket-address ${TCP_SOCKET_ADDRESS} \
+  --neighboring-socket-port ${TCP_PORT} \
   --port $API_PORT \
-  --udp-receiver-port $UDP_PORT \
-  --tcp-receiver-port $TCP_PORT \
   --remote=true --remote-limit-api "$REMOTE_API_LIMIT" \
   --neighbors "$neighbors" \
   "$@"
-  
+

--- a/scripts/runDebugNode
+++ b/scripts/runDebugNode
@@ -1,8 +1,8 @@
 read -p "Hostname: " hostname
 
 docker run -d --name iota-node \
-    -p 14265:14265 -p 14777:14777/udp -p 15777:15777 \
-    --env API_PORT=14265 --env UDP_PORT=14777 --env TCP_PORT=15777 \
+    -p 14265:14265  -p 15777:15777 \
+    --env API_PORT=14265 --env TCP_PORT=15777 \
     -v $data_volume:/iri/data -v $conf_volume:/iri/conf \
     --env MIN_MEMORY=2g --env MAX_MEMORY=4g \
     --restart=no \

--- a/scripts/runNode
+++ b/scripts/runNode
@@ -1,6 +1,6 @@
 docker run -d --name iota-node \
-    -p 14265:14265 -p 14777:14777/udp -p 15777:15777 \
-    --env API_PORT=14265 --env UDP_PORT=14777 --env TCP_PORT=15777 \
+    -p 14265:14265 -p 15777:15777 \
+    --env API_PORT=14265 --env TCP_PORT=15777 \
     -v $data_volume:/iri/data -v $conf_volume:/iri/conf \
     --env MIN_MEMORY=2g --env MAX_MEMORY=4g \
     --restart=always \


### PR DESCRIPTION
Removed UDP related configuration and references in documentation + scripts to support IRI 1.8.0.
- Introduced «--neighboring-socket-address» and «--neighboring-socket-port»
- Removed «--udp-receiver-port» and «--tcp-receiver-port»